### PR TITLE
引入的assets应该用绝对路径

### DIFF
--- a/web/preview.html
+++ b/web/preview.html
@@ -8,8 +8,8 @@
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
   <meta name="apple-touch-fullscreen" content="yes">
   <meta name="format-detection" content="telephone=no, email=no">
-  <link rel="stylesheet" href="./assets/preview.css">
-  <script src="./assets/qrcode.js"></script>
+  <link rel="stylesheet" href="/assets/preview.css">
+  <script src="/assets/qrcode.js"></script>
 </head>
 <body>
   <!-- <header class="header center">


### PR DESCRIPTION
不然的话，如果打开的页面地址在二级路径的时候会导致无法引入。比如设置 entry的filename为 /pages/home.html的时候。