### PR TITLE
增加vue loader 判断闭合标签的 参数

### DIFF
--- a/index.js
+++ b/index.js
@@ -148,7 +148,11 @@ module.exports = (api, options) => {
                                 // to convert vnode for weex components.
                                 require('weex-vue-precompiler')()(el)
                             }
-                        }]
+                        }],
+                        isUnaryTag: makeMap(
+                            'area,base,br,col,embed,frame,hr,img,image,input,isindex,keygen,' +
+                            'link,meta,param,source,track,wbr'
+                        ), // 这里主要是添加了image标签的支持，因为format函数会把image的闭合给干掉，但是vue默认又是要检测的，所以这里新增允许image不闭合
                     }
                 })
         }
@@ -162,4 +166,26 @@ function generateLoaders(loader) {
             sourceMap: false
         }
     }]
+}
+
+/**
+ * Make a map and return a function for checking if a key
+ * is in that map.
+ */
+function makeMap(
+    str,
+    expectsLowerCase
+) {
+    var map = Object.create(null);
+    var list = str.split(',');
+    for (var i = 0; i < list.length; i++) {
+        map[list[i]] = true;
+    }
+    return expectsLowerCase ?
+        function (val) {
+            return map[val.toLowerCase()];
+        } :
+        function (val) {
+            return map[val];
+        }
 }


### PR DESCRIPTION
因为weex有image标签，image标签在weex和format工具里都是不需要闭合的，但是vueloader默认配置是必须要闭合，这里会有冲突，所以自定义了是否是闭合标签的判断。